### PR TITLE
Legger til støtte for at antallDagerIgjen kan være negative

### DIFF
--- a/src/main/kotlin/no/nav/helse/CalendarArithmetic.kt
+++ b/src/main/kotlin/no/nav/helse/CalendarArithmetic.kt
@@ -11,14 +11,22 @@ tailrec fun nWeekdaysFrom(n: Int, from: LocalDate): LocalDate =
    }
 
 
-tailrec fun nextWeekday(after: LocalDate): LocalDate {
-   val nextDay = after.plusDays(1)
-   return if (isWeekend(nextDay)) nextWeekday(nextDay) else nextDay
+fun nextWeekday(date: LocalDate): LocalDate {
+   val daysToAdd: Long = when (date.dayOfWeek) {
+      FRIDAY -> 3
+      SATURDAY -> 2
+      else -> 1
+   }
+   return date.plusDays(daysToAdd)
 }
 
-tailrec fun previousWeekday(after: LocalDate): LocalDate {
-   val previousDay = after.minusDays(1)
-   return if (isWeekend(previousDay)) previousWeekday(previousDay) else previousDay
+fun previousWeekday(date: LocalDate): LocalDate {
+   val daysToExtract: Long = when (date.dayOfWeek) {
+      MONDAY -> 3
+      SUNDAY -> 2
+      else -> 1
+   }
+   return date.minusDays(daysToExtract)
 }
 
 fun isWeekend(date: LocalDate): Boolean =

--- a/src/main/kotlin/no/nav/helse/CalendarArithmetic.kt
+++ b/src/main/kotlin/no/nav/helse/CalendarArithmetic.kt
@@ -4,11 +4,21 @@ import java.time.*
 import java.time.DayOfWeek.*
 
 tailrec fun nWeekdaysFrom(n: Int, from: LocalDate): LocalDate =
-   if (n == 0) from else nWeekdaysFrom(n - 1, nextWeekday(from))
+   when {
+      n < 0 -> nWeekdaysFrom(n + 1, previousWeekday(from))
+      n == 0 -> from
+      else -> nWeekdaysFrom(n - 1, nextWeekday(from))
+   }
+
 
 tailrec fun nextWeekday(after: LocalDate): LocalDate {
    val nextDay = after.plusDays(1)
    return if (isWeekend(nextDay)) nextWeekday(nextDay) else nextDay
+}
+
+tailrec fun previousWeekday(after: LocalDate): LocalDate {
+   val previousDay = after.minusDays(1)
+   return if (isWeekend(previousDay)) previousWeekday(previousDay) else previousDay
 }
 
 fun isWeekend(date: LocalDate): Boolean =

--- a/src/main/kotlin/no/nav/helse/Sykepengedager.kt
+++ b/src/main/kotlin/no/nav/helse/Sykepengedager.kt
@@ -14,7 +14,7 @@ fun maksdato(grunnlag: Grunnlagsdata): MaksdatoResult {
 fun dagerTilgode(grunnlag: Grunnlagsdata): Pair<Int, String> {
    val maxTilgjengeligeDager = maxTilgjengeligeDager(grunnlag.personensAlder, grunnlag.yrkesstatus)
    val forbrukt = dagerForbrukt(grunnlag.førsteFraværsdag, grunnlag.tidligerePerioder.sortedByDescending { it.tom })
-   val tilgode = if (forbrukt >= maxTilgjengeligeDager) 0 else maxTilgjengeligeDager - forbrukt
+   val tilgode = maxTilgjengeligeDager - forbrukt
    val begrunnelse = "${grunnlag.yrkesstatus} på ${grunnlag.personensAlder} år gir maks $maxTilgjengeligeDager dager. " +
       "$forbrukt av disse er forbrukt"
    return Pair(tilgode, begrunnelse)

--- a/src/main/kotlin/no/nav/helse/Sykepengedager.kt
+++ b/src/main/kotlin/no/nav/helse/Sykepengedager.kt
@@ -13,7 +13,7 @@ fun maksdato(grunnlag: Grunnlagsdata): MaksdatoResult {
 
 fun dagerTilgode(grunnlag: Grunnlagsdata): Pair<Int, String> {
    val maxTilgjengeligeDager = maxTilgjengeligeDager(grunnlag.personensAlder, grunnlag.yrkesstatus)
-   val forbrukt = dagerForbrukt(grunnlag.førsteFraværsdag, grunnlag.tidligerePerioder)
+   val forbrukt = dagerForbrukt(grunnlag.førsteFraværsdag, grunnlag.tidligerePerioder.sortedByDescending { it.tom })
    val tilgode = if (forbrukt >= maxTilgjengeligeDager) 0 else maxTilgjengeligeDager - forbrukt
    val begrunnelse = "${grunnlag.yrkesstatus} på ${grunnlag.personensAlder} år gir maks $maxTilgjengeligeDager dager. " +
       "$forbrukt av disse er forbrukt"

--- a/src/test/kotlin/no/nav/helse/CalendarArithmeticTests.kt
+++ b/src/test/kotlin/no/nav/helse/CalendarArithmeticTests.kt
@@ -29,10 +29,12 @@ object CalendarArithmeticTest: Spek({
          }
 
          on ("any day of the week") {
-            it("is calculates a date x amount of weekdays into the future") {
+            it("is calculates a date x amount of weekdays into the future or back to the past") {
                val testcases = mapOf(
                   Pair(LocalDate.of(2015, 11, 26), 2) to LocalDate.of(2015, 11, 30),
-                  Pair(LocalDate.of(2019, 1, 4), 3) to LocalDate.of(2019, 1, 9)
+                  Pair(LocalDate.of(2015, 11, 30), -2) to LocalDate.of(2015, 11, 26),
+                  Pair(LocalDate.of(2019, 1, 4), 3) to LocalDate.of(2019, 1, 9),
+                  Pair(LocalDate.of(2019, 1, 9), -3) to LocalDate.of(2019, 1, 4)
                )
 
                testcases.forEach {


### PR DESCRIPTION
Hvis antallDager sendt til nWeekdaysFrom er negativt, regnes tidligere (passert) maksdato ut.

Sorterer også listen over tidligere perioder før beregning.

Sees I sammenheng med: https://github.com/navikt/helse-spa/pull/10